### PR TITLE
added catch for errors thrown by findOne in lock_try #413

### DIFF
--- a/src/mongo/client/distlock.cpp
+++ b/src/mongo/client/distlock.cpp
@@ -511,7 +511,7 @@ namespace mongo {
         queryBuilder.appendElements( _id );
         queryBuilder.append( "state" , 0 );
 
-        {
+        try {
             // make sure its there so we can use simple update logic below
             BSONObj o = conn->findOne( locksNS , _id ).getOwned();
 
@@ -718,6 +718,40 @@ namespace mongo {
             else if ( o["ts"].type() ) {
                 queryBuilder.append( o["ts"] );
             }
+        }
+        catch (storage::RetryableException) {
+            conn.done();
+            return false;
+        }
+        catch (UserException &e) {
+            int code = e.getCode();
+            if (code == 13106) {
+                // DBClientCursor::nextSafe (inside DBClientInterface::findOne) throws exceptions
+                // with the code 13106 and the string "nextSafe(): " concatenated with the BSONObj
+                // returned by the query.  We need to look at this string to figure out the original
+                // error code.  This is not ideal, but we have to deal with the C++ driver's
+                // weirdness here.
+
+                // Expected format:
+                // nextSafe(): { $err: "Lock not granted. Try restarting the transaction.", code: 16759 }
+                StringData err = e.what();
+                StringData prefix("nextSafe(): ");
+                if (!err.startsWith(prefix)) {
+                    throw;
+                }
+                StringData objStr = err.substr(prefix.size(), string::npos);
+                BSONObj errObj = fromjson(objStr.toString());
+                BSONElement codeElt = errObj["code"];
+                if (!codeElt.ok() || !codeElt.isNumber()) {
+                    throw;
+                }
+                long long wrappedCode = codeElt.numberLong();
+                if (wrappedCode == 16759 || wrappedCode == 16760 || wrappedCode == 16768) {
+                    conn.done();
+                    return false;
+                }
+            }
+            throw;
         }
 
         // Always reset our ping if we're trying to get a lock, since getting a lock implies the lock state is open


### PR DESCRIPTION
In DistributedLock, we need to catch retryable errors (lock not granted,
etc.) and actually retry, rather than letting the exception terminate
the process.  findOne can throw an exception that doesn't look
retryable, because it wraps every query error in its own exception with
a fixed code, and adds the returned error BSON as a string in the
explanation (see DBClientCursor::nextSafe).  Since we use findOne in
lock_try, we need to pick apart this particular exception and look at
the string we got to decode the actual error and see if we should just
retry.

closes #413
