### PR TITLE
added automatic save/resume functionality to mongo2toku #495

### DIFF
--- a/src/mongo/tools/2toku.cpp
+++ b/src/mongo/tools/2toku.cpp
@@ -283,7 +283,7 @@ public:
             try {
                 std::ofstream tsFile;
                 tsFile.exceptions(std::ifstream::badbit | std::ifstream::failbit);
-                tsFile.open(_tsFilename);
+                tsFile.open(_tsFilename, std::ofstream::trunc);
                 tsFile << tsString;
                 tsFile.close();
                 log() << "Saved timestamp to file "


### PR DESCRIPTION
On exit, in addition to logging the --ts value needed for resume, we also save it to
a file `__mongo2toku_saved_timestamp__` and try to read out of that file on resume.

fixes #495
