### PR TITLE
changed writeEntryToOplog to not double-count #689

### DIFF
--- a/src/mongo/db/oplog.h
+++ b/src/mongo/db/oplog.h
@@ -45,7 +45,7 @@ namespace mongo {
     GTID getGTIDFromOplogEntry(BSONObj o);
     bool getLastGTIDinOplog(GTID* gtid);
     bool gtidExistsInOplog(GTID gtid);
-    void writeEntryToOplog(BSONObj entry);
+    void writeEntryToOplog(BSONObj entry, bool recordStats);
     void writeEntryToOplogRefs(BSONObj entry);
     void replicateFullTransactionToOplog(BSONObj& o, OplogReader& r, bool* bigTxn);
     void applyTransactionFromOplog(BSONObj entry);


### PR DESCRIPTION
Previously, writeEntryToOplog would record serverStatus statistics on
oplog insertion once when the secondary inserted the op and again when it
applied the op and set the applied bit.  Now, we just record stats once
and don't record them a second time when we set the applied bit.  This
matches mongodb's expected behavior more closely, and in particular will
make the primary and secondaries count the same number of objects.

fixes #689
