### PR TITLE
mongos always uses the first shard as the primary shard

### DIFF
--- a/src/mongo/s/balance.cpp
+++ b/src/mongo/s/balance.cpp
@@ -234,7 +234,7 @@ namespace mongo {
             const Shard& s = *it;
             ShardStatus status = s.getStatus();
             shardInfo[ s.getName() ] = ShardInfo( s.getMaxSize(),
-                                                  status.mapped(),
+                                                  status.datasize(),
                                                   s.isDraining(),
                                                   status.hasOpsQueued(),
                                                   s.tags(),

--- a/src/mongo/s/shard.cpp
+++ b/src/mongo/s/shard.cpp
@@ -365,7 +365,8 @@ namespace mongo {
     }
 
     ShardStatus Shard::getStatus() const {
-        return ShardStatus( *this , runCommand( "admin" , BSON( "serverStatus" << 1 ) , true ) );
+        return ShardStatus( *this , runCommand( "admin" , BSON( "serverStatus" << 1 ) , true ) ,
+                                    runCommand( "admin" , BSON( "listDatabases" << 1 ) , true ) );
     }
 
     void Shard::reloadShardInfo() {
@@ -403,9 +404,9 @@ namespace mongo {
         return best.shard();
     }
 
-    ShardStatus::ShardStatus( const Shard& shard , const BSONObj& obj )
+    ShardStatus::ShardStatus( const Shard& shard , const BSONObj& obj , const BSONObj& dblistobj )
         : _shard( shard ) {
-        _mapped = obj.getFieldDotted( "mem.mapped" ).numberLong();
+        _dataSize = dblistobj.getFieldDotted("totalSize").numberLong();
         _hasOpsQueued = obj["writeBacksQueued"].Bool();
         _writeLock = 0; // TODO
         _mongoVersion = obj["version"].String();

--- a/src/mongo/s/shard.h
+++ b/src/mongo/s/shard.h
@@ -175,7 +175,7 @@ namespace mongo {
     class ShardStatus {
     public:
 
-        ShardStatus( const Shard& shard , const BSONObj& obj );
+        ShardStatus( const Shard& shard , const BSONObj& obj, const BSONObj& dblistobj );
 
         friend ostream& operator << (ostream& out, const ShardStatus& s) {
             out << s.toString();
@@ -185,22 +185,22 @@ namespace mongo {
         string toString() const {
             stringstream ss;
             ss << "shard: " << _shard 
-               << " mapped: " << _mapped 
+               << " dataSize: " << _dataSize
                << " writeLock: " << _writeLock
                << " version: " << _mongoVersion;
             return ss.str();
         }
 
         bool operator<( const ShardStatus& other ) const {
-            return _mapped < other._mapped;
+            return _dataSize < other._dataSize;
         }
 
         Shard shard() const {
             return _shard;
         }
 
-        long long mapped() const {
-            return _mapped;
+        long long datasize() const {
+            return _dataSize;
         }
 
         bool hasOpsQueued() const {
@@ -213,7 +213,7 @@ namespace mongo {
 
     private:
         Shard _shard;
-        long long _mapped;
+        long long _dataSize;
         bool _hasOpsQueued;  // true if 'writebacks' are pending
         double _writeLock;
         string _mongoVersion;


### PR DESCRIPTION
This change fixes issue #422 

**Problem**

Vanilla mongodb had the `mem.mapped` property that was used to determine the shard that was least loaded. And whenever a new database was enabled for sharding, the mongos would place the database primary on that. This was broken when tokumx removed the `mem.mapped` attribute from the output of `serverStatus` command. 

**Proposed change**

This change fixes this error by using the `listDatabases` command to get the `totalSize` of databases on disk for selecting the best shard to place the primary when enabling sharding on a new database.

In addition to the above change, the variable name has been changed to `_dataSize` and the accessor to `datasize()` as the old names were no longer representative of the data stored within them. 

**Acceptance Criteria**
- The primary shard selection if based on the disk utilization size (as was the intent in vanilla mongodb) and spread out amongst all shards.
- All old functionality continues to work
- Existing sharded databases/collections are not affected by this change.
