### PR TITLE
Update `show collections` to report collection sizes

### DIFF
--- a/src/mongo/shell/utils.js
+++ b/src/mongo/shell/utils.js
@@ -761,18 +761,12 @@ shellHelper.show = function (what) {
     }
 
     if (what == "collections" || what == "tables") {
-        var colls = db.getCollectionNames();
-        var size  = {};
-        var uncompressedSize = {};
-        colls.forEach(function (x) {
-          var c = db.runCommand({collStats : x, scale : 1}); 
-          uncompressedSize[x] = c.storageSize
-          size[x] = c.size + c.totalIndexSize
-        });
-        var names = colls.sort();
-        names.forEach(function(n) {
-          if (size[n] > 1) {
-                print(n + "\t" + shellHelper._prettyBytes(uncompressedSize[n]) + " (uncompressed),\t" + shellHelper._prettyBytes(size[n]) + " (compressed)");
+        db.getCollectionNames().forEach(function (n) {
+          var c = db.runCommand({collStats : n, scale : 1}); 
+          var uncompressedSize = c.size + c.totalIndexSize;
+          var compressedSize = c.storageSize + c.totalIndexStorageSize;
+          if (compressedSize > 1) {
+                print(n + "\t" + shellHelper._prettyBytes(uncompressedSize) + " (uncompressed),\t" + shellHelper._prettyBytes(compressedSize) + " (compressed)");
             } else {
                 print(n + "\t(empty)");
             }


### PR DESCRIPTION
This change intends to make the result of `show dbs` and `show collections` somewhat similar. The idea is that when a user issues `show collection` we should also display the compressed and uncompressed sizes of the collections in the current database.
