### PR TITLE
control behavior of show dbs with an environment variable

### DIFF
--- a/src/mongo/db/collection_map.cpp
+++ b/src/mongo/db/collection_map.cpp
@@ -122,7 +122,7 @@ namespace mongo {
                 const string &ns = obj["ns"].String();
                 e->tofill.push_back(ns);
             }
-            return 0;
+            return TOKUDB_CURSOR_CONTINUE;
         }
         catch (std::exception &ex) {
             e->saveException(ex);

--- a/src/mongo/db/dbcommands.cpp
+++ b/src/mongo/db/dbcommands.cpp
@@ -1121,7 +1121,7 @@ namespace mongo {
                 BSONObjBuilder b;
                 b.append( "name", *i );
 
-                {
+                if (!getenv("TOKUMX_SHOW_NO_SIZES")){
                     LOCK_REASON(lockReason, "listDatabases: getting db size");
                     Client::ReadContext rc( getSisterNS(*i, "system.namespaces"), lockReason );
                     size_t uncompressedSize = 0;

--- a/src/mongo/db/instance.cpp
+++ b/src/mongo/db/instance.cpp
@@ -986,7 +986,7 @@ namespace mongo {
                 e->names.push_back(string((char *) key->data, length - 3));
             }
         }
-        return 0;
+        return TOKUDB_CURSOR_CONTINUE;
     } 
 
     void getDatabaseNames( vector< string > &names) {


### PR DESCRIPTION
make getNamespaces() and getDatabases use bulk fetch
have an environment variable disable showing sizes of "show dbs"
