### PR TITLE
Invalid links in debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,42 +1,42 @@
 tokumx (1.6.0-pre-) UNRELEASED; urgency=low
 
-  * see http://github.com/Tokutek/mongo/releases/1.6.0
+  * see http://github.com/Tokutek/mongo/releases/tag/tokumx-1.6.0
 
  -- Leif Walsh <leif.walsh@gmail.com>  Mon, 08 Sep 2014 23:07:43 +0000
 
 tokumx (1.5.1) unstable; urgency=low
 
-  * see http://github.com/Tokutek/mongo/releases/1.5.1
+  * see http://github.com/Tokutek/mongo/releases/tag/tokumx-1.5.1
 
  -- Leif Walsh <leif.walsh@gmail.com>  Mon, 08 Sep 2014 23:05:22 +0000
 
 tokumx (1.5.0) unstable; urgency=low
 
-  * see http://github.com/Tokutek/mongo/releases/1.5.0
+  * see http://github.com/Tokutek/mongo/releases/tag/tokumx-1.5.0
 
  -- Leif Walsh <leif.walsh@gmail.com>  Mon, 16 Jun 2014 21:26:46 +0000
 
 tokumx (1.4.3) unstable; urgency=low
 
-  * see http://github.com/Tokutek/mongo/releases/1.4.3
+  * see http://github.com/Tokutek/mongo/releases/tag/tokumx-1.4.3
 
  -- Leif Walsh <leif.walsh@gmail.com>  Mon, 09 Jun 2014 19:17:43 +0000
 
 tokumx (1.4.2) unstable; urgency=low
 
-  * see http://github.com/Tokutek/mongo/releases/1.4.2
+  * see http://github.com/Tokutek/mongo/releases/tag/tokumx-1.4.2
 
  -- Leif Walsh <leif.walsh@gmail.com>  Thu, 08 May 2014 16:12:28 +0000
 
 tokumx (1.4.1) unstable; urgency=low
 
-  * see http://github.com/Tokutek/mongo/releases/1.4.1
+  * see http://github.com/Tokutek/mongo/releases/tag/tokumx-1.4.1
 
  -- Leif Walsh <leif.walsh@gmail.com>  Fri, 21 Mar 2014 12:56:31 +0000
 
 tokumx (1.4.0) unstable; urgency=low
 
-  * see http://github.com/Tokutek/mongo/releases/1.4.0
+  * see http://github.com/Tokutek/mongo/releases/tag/tokumx-1.4.0
 
  -- Leif Walsh <leif.walsh@gmail.com>  Wed, 12 Feb 2014 02:05:14 +0000
 


### PR DESCRIPTION
Debian's changelog has been updated to provide valid release links (well, except for 1.6.0)
