### PR TITLE
Fixed the user guide link in mongo shell

### DIFF
--- a/debian/tokumx.conf
+++ b/debian/tokumx.conf
@@ -3,7 +3,7 @@
 # This configuration file contains most of the useful options and their
 # defaults for TokuMX.  For the full set of all available options, see
 # the Users' Guide available at
-# http://www.tokutek.com/products/downloads/tokumx-ce-downloads/
+# https://www.percona.com/doc/percona-tokumx/
 
 ########################################################################
 # PROCESS OPTIONS

--- a/rpm/tokumx.conf
+++ b/rpm/tokumx.conf
@@ -3,7 +3,7 @@
 # This configuration file contains most of the useful options and their
 # defaults for TokuMX.  For the full set of all available options, see
 # the Users' Guide available at
-# http://www.tokutek.com/products/downloads/tokumx-ce-downloads/
+# https://www.percona.com/doc/percona-tokumx/
 
 ########################################################################
 # PROCESS OPTIONS

--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -903,7 +903,7 @@ int _main( int argc, char* argv[], char **envp ) {
            cout << "Welcome to the TokuMX shell.\n"
                    "For interactive help, type \"help\".\n"
                    "For more comprehensive documentation, see\n\thttp://docs.mongodb.org/\n"
-                   "and the TokuMX Users' Guide available at\n\thttp://www.tokutek.com/products/downloads/tokumx-ce-downloads/\n"
+                   "and the TokuMX Users' Guide available at\n\thttps://www.percona.com/doc/percona-tokumx/\n"
                    "Questions? Try the support group\n\thttp://groups.google.com/group/tokumx-user" << endl;
            fstream f;
            f.open(rcLocation.c_str(), ios_base::out );


### PR DESCRIPTION
Fixed the user guide link in mongo shell which is now available at: https://www.percona.com/doc/percona-tokumx/
I made a change in packaging files also although we don't use those any more but have a separate repo for it.
