### PR TITLE
Add a capability to set a timeout on the connection of  mongos and mongod shards

### DIFF
--- a/src/mongo/s/shard.h
+++ b/src/mongo/s/shard.h
@@ -297,6 +297,9 @@ namespace mongo {
         // Controls whether we throw on initially failing to set a version
         static bool ignoreInitialVersionFailure;
 
+        // Use for settings timeout for connections between mongos and mongod
+        static double shardConnectionTimeout;
+
         /** checks all of my thread local connections for the version of this ns */
         static void checkMyConnectionVersions( const string & ns );
 


### PR DESCRIPTION
Hello,  we faced the  following problem:  when one shard with mongod becomes  unavailable ( connection is refused, e.g. a box is powered off;  when mongos can't get some response from mongod within the adequate time), all mongoses from a shard cluster begin slowing down. It makes  all mongos wait for some response from the dead shard. As result, all mongoses start timouting. This patch introduces a new parameter for mongos which allows to set a timeout on the connection between mongoses and shards.
